### PR TITLE
Update chapter14.md

### DIFF
--- a/book/chapter14.md
+++ b/book/chapter14.md
@@ -73,6 +73,7 @@ function Player:new()
 	self.x = 300
 	self.y = 20
 	self.speed = 500
+	self.width = self.image:getWidth() 
 end
 
 function Player:update(dt)


### PR DESCRIPTION
self.width was missing in the Player:new function. This prevents an error when self.width is used to keep our player from moving too far to the right.