### PR TITLE
Fix typo in chapter 2

### DIFF
--- a/book/chapter2.md
+++ b/book/chapter2.md
@@ -58,7 +58,7 @@ are three different variables, with each their own value.
 
 You can do more than just summing up numbers.
 ```lua
-a = 20 - 10 --Substraction
+a = 20 - 10 --Subtraction
 b = 20 * 10 --Multiplication
 c = 20 / 10 --Division
 d = 20 ^ 10 --Exponentiation


### PR DESCRIPTION
In the maths operations sections the subtraction operation is incorrectly labelled as substraction.